### PR TITLE
formular bug

### DIFF
--- a/depth_from_defocus.py
+++ b/depth_from_defocus.py
@@ -91,7 +91,7 @@ sdm = np.zeros_like(ratio)
 mx, my = np.where(edge_map * (ratio > 1.01) * (ratio <= std_2/std_1))
 
 # enhancement
-sdm[mx,my] = np.sqrt((ratio[mx,my]**2 * (std_1**2 - std_2**2) + 0.001) / (1 - ratio[mx,my]**2))
+sdm[mx,my] = np.sqrt(((ratio[mx,my]**2 * std_1**2 - std_2**2) + 0.001) / (1 - ratio[mx,my]**2))
 
 # clip
 max_blur = 3


### PR DESCRIPTION
I think the formula in depth_from_defocus.py line 94 is wrong.

deduced from the paper, the formula should be
R = sqrt( (std ** 2 + std_2 ** 2) / (std ** 2 + std_1 ** 2) )
then
std = sqrt( (R ** 2 * std_1 ** 2 - std_2 ** 2) / (1 - R ** 2) )
